### PR TITLE
Black Duck: Upgrade zaproxy to version 0.3.0 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nodemon": "^1.19.1",
     "selenium-webdriver": "^2.53.2",
     "should": "^8.3.1",
-    "zaproxy": "^0.2.0"
+    "zaproxy": "^0.3.0"
   },
   "repository": "https://github.com/OWASP/NodejsGoat",
   "license": "Apache 2.0"


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade zaproxy from version 0.2.0 to 0.3.0 in order to fix security vulnerabilities:

The direct dependency zaproxy/0.2.0 has 14 vulnerabilities in child dependencies (max score 9.8).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Direct Dep Changed |
| --- | --- | --- | --- | --- | --- | --- |
| zaproxy/0.2.0 | cryptiles/0.2.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/CVE-2018-1000620/overview" target="_blank">CVE-2018-1000620</a> | 9.8 | Not-Pixiapp security (project-specific) | Eran Hammer cryptiles version 4.1.1 earlier contains a CWE-331: Insufficient Entropy vulnerability in randomDigits() method that can result in An attacker is more likely to be able to brute force  ... | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2019-2112/overview" target="_blank">BDSA-2019-2112</a> | 8.8 | No Critical Vulns | Lodash contains a prototype pollution flaw. An attacker could exploit this to modify the component or cause remote code execution or a denial-of-service (*DoS*). | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-1674/overview" target="_blank">BDSA-2020-1674</a> | 8.8 | No Critical Vulns | Lodash is vulnerable to remote code execution (RCE) due to the potential to modify the properties of objects in memory. A remote attacker could run arbitrary commands on a vulnerable server, or ca ... | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-0392/overview" target="_blank">BDSA-2021-0392</a> | 8.8 | No Critical Vulns | Lodash is vulnerable to command injection via the `template` function. An attacker can take advantage of this vulnerability in order to run arbitrary commands. | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-3839/overview" target="_blank">BDSA-2020-3839</a> | 8.5 | Old and Insecure Components | lodash is vulnerable to a prototype pollution flaw. A remote attacker may be able to supply specially crafted input to cause serious confidentiality, integrity and availability impacts to the appl ... | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-3818/overview" target="_blank">BDSA-2018-3818</a> | 7.4 | Old and Insecure Components | Lodash is vulnerable to denial-of-service (DoS) as the user-controllable input to certain functions is not sufficiently checked, allowing an attacker to add or modify existing properties of presum ... | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2019-3842/overview" target="_blank">BDSA-2019-3842</a> | 7.1 | Old and Insecure Components | Lodash contains a denial-of-service (DoS) vulnerability.  This is due to multiple methods not validating the length of content supplied to it.  If an application is passing untrusted-input to the  ... | No |
| zaproxy/0.2.0 | tunnel-agent/0.4.3 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-1529/overview" target="_blank">BDSA-2018-1529</a> | 6.7 | Old and Insecure Components | Tunnel-Agent contains a memory exposure vulnerability due to improper input validation allowing a numeric value for `auth`. | No |
| zaproxy/0.2.0 | request/2.36.0 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2017-2926/overview" target="_blank">BDSA-2017-2926</a> | 6.7 | Old and Insecure Components | Request contains a memory disclosure vulnerability due to issues in file `liv/multipart.js` with `multipart` attachments. A remote attacker is able to gain a specified number of non-zero memory du ... | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-0375/overview" target="_blank">BDSA-2021-0375</a> | 6.7 | Old and Insecure Components | Lodash contains a denial-of-service (DoS) vulnerability. An attacker can exploit this using crafted regular expressions to exhaust system resources. | No |
| zaproxy/0.2.0 | qs/0.6.6 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2014-0079/overview" target="_blank">BDSA-2014-0079</a> | 6.5 | Old and Insecure Components | Node.js module `qs` is vulnerable to a denial-of-service.  An attacker can exploit this vulnerability by suppling`qs` with a crafted string that deserializes into very large sparse arrays, resulti ... | No |
| zaproxy/0.2.0 | qs/0.6.6 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2014-0064/overview" target="_blank">BDSA-2014-0064</a> | 6.5 | Old and Insecure Components | qs Module is vulnerable to a denial-of-service (DoS) triggered by excessive recursion in parsing a deeply nested JSON string. An attacker can submit a specially crafted string to crash the module. | No |
| zaproxy/0.2.0 | lodash/2.4.2 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/CVE-2019-1010266/overview" target="_blank">CVE-2019-1010266</a> | 6.5 | Old and Insecure Components | lodash prior to 4.17.11 is affected by: CWE-400: Uncontrolled Resource Consumption. The impact is: Denial of service. The component is: Date handler. The attack vector is: Attacker provides very l ... | No |
| zaproxy/0.2.0 | hawk/1.0.0 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2016-0224/overview" target="_blank">BDSA-2016-0224</a> | 6.5 | Old and Insecure Components | Hawk, a HTTP authentication scheme, is vulnerable to regular expression denial-of-service (*ReDoS*) due to its implementation of pattern matching. | No |
