### PR TITLE
Black Duck: Upgrade marked to version 0.8.2 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express-session": "^1.13.0",
     "forever": "^2.0.0",
     "helmet": "^2.0.0",
-    "marked": "0.3.9",
+    "marked": "^0.8.2",
     "mongodb": "^2.1.18",
     "needle": "2.2.4",
     "node-esapi": "0.0.1",


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade marked from version 0.3.9 to 0.8.2 in order to fix security vulnerabilities:

The direct dependency marked/0.3.9 has 2 vulnerabilities (max score 6.7).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Direct Dep Changed |
| --- | --- | --- | --- | --- | --- | --- |
| -/- | marked/0.3.9 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2022-0105/overview" target="_blank">BDSA-2022-0105</a> | 6.7 | Old and Insecure Components | Marked is vulnerable to regular expression denial of service (ReDoS) due to a flaw present within a regular expression in the `src/rules.js` file. An attacker could exploit this vulnerability by s ... | No |
| -/- | marked/0.3.9 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2022-0106/overview" target="_blank">BDSA-2022-0106</a> | 6.7 | Old and Insecure Components | Marked is vulnerable to regular expression denial of service (ReDoS) due to a flaw present within a regular expression in the `src/rules.js` file. An attacker could exploit this vulnerability by s ... | No |
