### PR TITLE
Black Duck: Upgrade grunt-mocha-test to version 0.13.3 fix known security vulerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-env": "latest",
     "grunt-if": "https://github.com/binarymist/grunt-if/tarball/master",
     "grunt-jsbeautifier": "^0.2.12",
-    "grunt-mocha-test": "^0.12.7",
+    "grunt-mocha-test": "^0.13.3",
     "grunt-npm-install": "^0.3.0",
     "grunt-retire": "^0.3.12",
     "mocha": "^2.4.5",


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade grunt-mocha-test from version 0.12.7 to 0.13.3 in order to fix security vulnerabilities:

The direct dependency grunt-mocha-test/0.12.7 has 1 vulnerabilities in child dependencies (max score 7.3).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Direct Dep Changed |
| --- | --- | --- | --- | --- | --- | --- |
| grunt-mocha-test/0.12.7 | minimist/0.0.8 | <a href="https://testing.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-4373/overview" target="_blank">BDSA-2020-4373</a> | 7.3 | No Critical Vulns | minimist is vulnerable to a prototype pollution attack. A remote attacker may be able to execute arbitrary code, or cause a denial-of-service (DoS) by tricking the library into modifying or adding ... | No |
